### PR TITLE
Fix parsing of not quoted mailbox names containing squared brackets returned by a LIST/LSUB command (like Dovecot does)

### DIFF
--- a/imap/reader_test.go
+++ b/imap/reader_test.go
@@ -334,9 +334,9 @@ func TestReaderParse(t *testing.T) {
 		{`* Literal {0}` + CRLF + ` {2}` + CRLF + `hi x ~{3}` + CRLF + "\x00\r\n",
 			&Response{Tag: "*", Type: Data, Label: "LITERAL", Fields: []Field{
 				"Literal", lit(""), lit("hi"), "x", lit8("\x00\r\n")}}},
-		{`* List () ((()) (x ())) ((y) z)`,
-			&Response{Tag: "*", Type: Data, Label: "LIST", Fields: []Field{
-				"List", []Field(nil), []Field{[]Field{[]Field(nil)}, []Field{"x", []Field(nil)}}, []Field{[]Field{"y"}, "z"}}}},
+		{`* ParenthesizedList () ((()) (x ())) ((y) z)`,
+			&Response{Tag: "*", Type: Data, Label: "PARENTHESIZEDLIST", Fields: []Field{
+				"ParenthesizedList", []Field(nil), []Field{[]Field{[]Field(nil)}, []Field{"x", []Field(nil)}}, []Field{[]Field{"y"}, "z"}}}},
 		{`* NIL_ NIL nil Nil (NIL) "NIL"`,
 			&Response{Tag: "*", Type: Data, Label: "NIL_", Fields: []Field{
 				"NIL_", nil, nil, nil, []Field{nil}, `"NIL"`}}},

--- a/imap/response_test.go
+++ b/imap/response_test.go
@@ -66,6 +66,16 @@ func TestResponseDecoders(t *testing.T) {
 				Attrs: NewFlagSet(),
 				Delim: "/",
 				Name:  "blurdybloop"}},
+		{`* LSUB () "/" [blurdybloop]`,
+			"MailboxInfo", &MailboxInfo{
+				Attrs: NewFlagSet(),
+				Delim: "/",
+				Name:  "[blurdybloop]"}},
+		{`* LSUB () "/" #foo.bar/[blurdybloop`,
+			"MailboxInfo", &MailboxInfo{
+				Attrs: NewFlagSet(),
+				Delim: "/",
+				Name:  "#foo.bar/[blurdybloop"}},
 		{`* LIST (\Noselect) "." "#foo.bar"`,
 			"MailboxInfo", &MailboxInfo{
 				Attrs: NewFlagSet(`\Noselect`),


### PR DESCRIPTION
Hi,

I tried to fix the parsing of not quoted mailbox names containing squared brackets returned by a LIST/LSUB command (Dovecot has this behavior).
RFC 3501 says that a mailbox name can be a quotes string, literal string or a astring:

mailbox-list    = "(" [mbx-list-flags] ")" SP
                   (DQUOTE QUOTED-CHAR DQUOTE / nil) SP mailbox

mailbox         = "INBOX" / astring

astring         = 1*ASTRING-CHAR / string

ASTRING-CHAR    = ATOM-CHAR / resp-specials

ATOM-CHAR       = <any CHAR except atom-specials>

atom-specials   = "(" / ")" / "{" / SP / CTL / list-wildcards /
                  quoted-specials / resp-specials

resp-specials   = "]"

The actual fix detects if the response is a LIST/LSUB response and then expects exactly 4 fields. The last one is the mailbox name.
A new method parseAstring is added.
The parseFields method is changed to accept a space as a stop character.
A test is added.

Thanks!
