### PR TITLE
handle long response lines from server

### DIFF
--- a/imap/transport.go
+++ b/imap/transport.go
@@ -156,16 +156,32 @@ func (t *transport) Closed() bool {
 // text. Otherwise, all bytes that have been read are returned unmodified along
 // with an error explaining the problem.
 func (t *transport) ReadLine() (line []byte, err error) {
-	line, err = t.buf.ReadSlice(lf)
-	n := len(line)
 
-	// Copy bytes out of the read buffer
-	if n > 0 {
-		temp := make([]byte, n)
-		copy(temp, line)
-		line = temp
-	} else {
-		line = nil
+	var (
+		chunk []byte
+		n     int
+	)
+	// read the response in chunks until end of line or err
+	// if the err is a full buffer, keep chunkin.
+	// if theres any err beyond full buffer, give up.
+	for err == bufio.ErrBufferFull || err == nil {
+		chunk, err = t.buf.ReadSlice(lf)
+		cn := len(chunk)
+		n += cn
+
+		// Copy chunk bytes out of the read buffer
+		if cn > 0 {
+			temp := make([]byte, cn)
+			copy(temp, chunk)
+			line = append(line, temp...)
+		} else {
+			line = nil
+		}
+
+		// No err? we can break and carry on
+		if err == nil {
+			break
+		}
 	}
 
 	// Check line format; if err == nil, the line ends with LF
@@ -182,8 +198,6 @@ func (t *transport) ReadLine() (line []byte, err error) {
 		} else {
 			err = &ProtocolError{"bad line ending", line}
 		}
-	} else if err == bufio.ErrBufferFull {
-		err = &ProtocolError{"line too long", line}
 	}
 	t.LogLine(server, line, err)
 	return

--- a/imap/transport.go
+++ b/imap/transport.go
@@ -174,14 +174,16 @@ func (t *transport) ReadLine() (line []byte, err error) {
 			temp := make([]byte, cn)
 			copy(temp, chunk)
 			line = append(line, temp...)
-		} else {
-			line = nil
 		}
 
 		// No err? we can break and carry on
 		if err == nil {
 			break
 		}
+	}
+
+	if n == 0 {
+		line = nil
 	}
 
 	// Check line format; if err == nil, the line ends with LF

--- a/imap/transport_test.go
+++ b/imap/transport_test.go
@@ -411,17 +411,13 @@ func TestTransportErrors(t *testing.T) {
 		C.Flush()
 	}
 
-	// Line too long (read)
+	// Line too long for a single chunk (read)
 	in = "hello, world!!!"
 	if err := S.send(in); err != nil {
 		t.Fatalf("S.send(%q) unexpected error; %v", in, err)
 	}
-	in += "\r"
-	for i := 0; i < 2; i++ {
-		if out, err := C.readln(); out != in || err == nil {
-			t.Fatalf("C.readln() expected %q; got %q (%v)", in, out, err)
-		}
-		in = "\n"
+	if out, err := C.readln(); out != in || err != nil {
+		t.Fatalf("C.readln() expected %q; got %q (%v)", in, out, err)
 	}
 
 	// Bad input

--- a/imap/transport_test.go
+++ b/imap/transport_test.go
@@ -412,7 +412,7 @@ func TestTransportErrors(t *testing.T) {
 	}
 
 	// Line too long for a single chunk (read)
-	in = "hello, world!!!"
+	in = "hello, world!!!!"
 	if err := S.send(in); err != nil {
 		t.Fatalf("S.send(%q) unexpected error; %v", in, err)
 	}


### PR DESCRIPTION
I have a scenario where a UID Search against Gmail might return a very large response. With the current implementation of `transport.ReadLine()`, the client errors and exits and I'm unable to get the search results.

To deal with longer lines without having to increase our buffer size, I've changed `transport.ReadLine()` to read the response in chunks until it encounters a non-`bufio.ErrBufferFull` error or an end of line.
