### PR TITLE
Should not limit the line length read from server response.

### DIFF
--- a/imap/transport.go
+++ b/imap/transport.go
@@ -156,15 +156,10 @@ func (t *transport) Closed() bool {
 // text. Otherwise, all bytes that have been read are returned unmodified along
 // with an error explaining the problem.
 func (t *transport) ReadLine() (line []byte, err error) {
-	line, err = t.buf.ReadSlice(lf)
+	line, err = t.buf.ReadBytes(lf)
 	n := len(line)
 
-	// Copy bytes out of the read buffer
-	if n > 0 {
-		temp := make([]byte, n)
-		copy(temp, line)
-		line = temp
-	} else {
+	if n == 0 {
 		line = nil
 	}
 
@@ -182,8 +177,6 @@ func (t *transport) ReadLine() (line []byte, err error) {
 		} else {
 			err = &ProtocolError{"bad line ending", line}
 		}
-	} else if err == bufio.ErrBufferFull {
-		err = &ProtocolError{"line too long", line}
 	}
 	t.LogLine(server, line, err)
 	return

--- a/imap/transport_test.go
+++ b/imap/transport_test.go
@@ -411,19 +411,6 @@ func TestTransportErrors(t *testing.T) {
 		C.Flush()
 	}
 
-	// Line too long (read)
-	in = "hello, world!!!"
-	if err := S.send(in); err != nil {
-		t.Fatalf("S.send(%q) unexpected error; %v", in, err)
-	}
-	in += "\r"
-	for i := 0; i < 2; i++ {
-		if out, err := C.readln(); out != in || err == nil {
-			t.Fatalf("C.readln() expected %q; got %q (%v)", in, out, err)
-		}
-		in = "\n"
-	}
-
 	// Bad input
 	tests := []string{
 		"* hello\r",


### PR DESCRIPTION
For example, Dovecot server may return a very long SEARCH response.
